### PR TITLE
Return removed builds to inventory

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -235,8 +235,10 @@ export class GameScene extends Phaser.Scene {
     const existing = this.state.placed.find(e => e.pos.x === gx && e.pos.y === gy);
     if (existing) {
       this.state.placed = this.state.placed.filter(e => e !== existing);
-      this.addEvent(`Removed ${existing.id} at (${gx}, ${gy})`);
+      this.state.inventory[existing.id] = (this.state.inventory[existing.id] || 0) + 1;
+      this.addEvent(`Removed ${existing.id} at (${gx}, ${gy}) and returned it to inventory`);
       this.redrawEntities();
+      this.updateAllUI();
       return;
     }
 


### PR DESCRIPTION
## Summary
- add inventory refund when removing placed entities
- refresh UI after removal so counts immediately reflect the refund

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f8891d3083238065b45e57fe02b4