### PR TITLE
Revise HUD links and overlay toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,19 @@
     <title>ecology.click</title>
     <style>
       html, body { margin:0; padding:0; height:100%; background:#0b0f12; color:#e6e8ea; font-family: ui-sans-serif, system-ui, -apple-system; }
-      :root { --overlay-toggle-row-height: 40px; }
       #app { height:100%; width:100%; }
       #ui-overlay { position:fixed; inset:0; pointer-events:none; z-index:5; }
       #ui-overlay > * { pointer-events:auto; }
-      .hud { position:fixed; top:8px; left:8px; background:#1118; padding:8px 12px; border-radius:8px; font-size:14px; }
+      .hud { position:fixed; top:8px; left:8px; background:#1118; padding:10px 14px; border-radius:10px; font-size:14px; display:flex; flex-direction:column; gap:6px; max-width:min(360px, 46vw); box-shadow:0 6px 18px #0008; }
+      .hud-links { display:flex; align-items:center; gap:8px; flex-wrap:wrap; font-size:13px; }
+      .hud-link { color:#94d0ff; text-decoration:none; font-weight:600; background:none; border:none; padding:0; cursor:pointer; font:inherit; display:inline-flex; align-items:center; gap:4px; }
+      .hud-link:hover, .hud-link:focus-visible { text-decoration:underline; outline:none; }
+      .hud-link:focus-visible { box-shadow:0 0 0 2px #94d0ff55; border-radius:4px; }
+      .hud-about { font-size:12px; line-height:1.5; color:#cfd8df; background:#0d151a; border:1px solid #1f2a33; border-radius:8px; padding:8px 10px; }
+      .hud-about a { color:#9cd8ff; text-decoration:underline; }
+      .hud-vitals { font-size:12px; color:#cfd8df; display:flex; align-items:center; gap:6px; flex-wrap:wrap; }
+      .hud-separator { opacity:0.6; }
+      .hud-vitals-label { font-weight:600; letter-spacing:0.02em; }
       .hotbar { position:fixed; bottom:8px; left:50%; transform:translateX(-50%); display:flex; gap:8px; background:#1118; padding:8px; border-radius:10px; }
       .slot { width:48px; height:48px; display:grid; place-items:center; border:1px solid #333; border-radius:8px; cursor:pointer; }
       .slot.active { outline:2px solid #7bd; }
@@ -40,7 +48,7 @@
       .queue-time { font-size:11px; color:#aaa; min-width:30px; text-align:right; }
       .cancel-btn { background:#d44; color:white; border:none; border-radius:3px; width:20px; height:20px; cursor:pointer; font-size:12px; }
       .cancel-btn:hover { background:#f66; }
-      .inventory-list { position:fixed; top:calc(12px + var(--overlay-toggle-row-height) * 4 + 12px); right:12px; width:200px; height:300px; background:#1118; border:1px solid #333; border-radius:8px; overflow-y:auto; padding:8px; }
+      .inventory-list { position:fixed; top:96px; right:12px; width:200px; height:300px; background:#1118; border:1px solid #333; border-radius:8px; overflow-y:auto; padding:8px; }
       .inventory-item { display:flex; justify-content:space-between; align-items:center; padding:4px 8px; margin-bottom:4px; border-radius:4px; }
       .inventory-item.resource { background:#1a2a1a; border:1px solid #4a6; }
       .inventory-item.item { background:#1a1a2a; border:1px solid #46a; }
@@ -51,8 +59,9 @@
       .overlay-hidden { display:none !important; }
       .ui-button { position:fixed; z-index:10; background:#111a; color:#e6e8ea; border:1px solid #2c3e4a; border-radius:999px; padding:8px 14px; font-size:13px; cursor:pointer; backdrop-filter:blur(8px); box-shadow:0 4px 12px #0006; transition:background 0.2s, transform 0.2s; touch-action:manipulation; }
       .ui-button:active { transform:scale(0.98); }
-      .overlay-toggle-group { position:fixed; top:12px; right:12px; display:flex; flex-direction:column; align-items:flex-end; gap:8px; z-index:10; }
-      .overlay-toggle-group .ui-button { position:static; width:180px; }
+      .overlay-toggle-group { position:fixed; top:12px; left:8px; right:8px; display:flex; flex-wrap:wrap; align-items:center; justify-content:flex-end; gap:8px; z-index:10; pointer-events:none; }
+      .overlay-toggle-group .ui-button { position:static; min-width:0; padding:6px 12px; font-size:12px; letter-spacing:0.02em; pointer-events:auto; }
+      .ui-button[data-active="false"] { opacity:0.6; border-color:#1f2a33; background:#0a1014aa; }
       #mode-toggle { bottom:12px; right:12px; }
       #mode-toggle[data-mode='move'] { background:#1a3820aa; border-color:#3a6a46; }
       #mode-toggle[data-mode='build'] { background:#38201aaa; border-color:#6a463a; }
@@ -72,7 +81,9 @@
         #ui-overlay > .event-log,
         #ui-overlay > .build-queue,
         #ui-overlay > .overlay-toggle-group { position:static; width:min(480px, 94vw); max-width:94vw; transform:none; left:auto; right:auto; }
+        .overlay-toggle-group { pointer-events:auto; justify-content:space-between; }
         .hud { text-align:center; }
+        .hud-links { justify-content:center; }
         .buildables-list,
         .inventory-list,
         .event-log,
@@ -89,12 +100,29 @@
   <body>
     <div id="app"></div>
     <div id="ui-overlay">
-      <div class="hud">ecology.click — WASD to pan, Mouse to place. (Prototype)</div>
+      <div class="hud">
+        <div class="hud-links">
+          <a class="hud-link" href="https://www.opensourceecology.org/" target="_blank" rel="noopener">Open Source Ecology</a>
+          <span class="hud-separator">·</span>
+          <button class="hud-link hud-about-toggle" id="hud-about-toggle" type="button" aria-expanded="false" aria-controls="hud-about">About this site</button>
+        </div>
+        <div class="hud-about" id="hud-about" hidden>
+          <p>You are the last working supply truck, stranded deep in the remote wilderness after civilization faltered.</p>
+          <p>Your mission is to rebuild society piece by piece using only the open blueprints from the <a href="https://wiki.opensourceecology.org/" target="_blank" rel="noopener">Open Source Ecology wiki</a>.</p>
+        </div>
+        <div class="hud-vitals">
+          <span class="hud-vitals-label">Vitals</span>
+          <span class="hud-separator">·</span>
+          <span>Health <span data-hud-health>100</span></span>
+          <span class="hud-separator">|</span>
+          <span>Thirst <span data-hud-thirst>100</span></span>
+        </div>
+      </div>
       <div id="overlay-toggle-group" class="overlay-toggle-group">
-        <button id="toggle-buildables" class="ui-button" type="button" aria-pressed="true" aria-controls="buildables-list">Hide Buildables</button>
-        <button id="toggle-inventory" class="ui-button" type="button" aria-pressed="true" aria-controls="inventory-list">Hide Inventory</button>
-        <button id="toggle-event-log" class="ui-button" type="button" aria-pressed="true" aria-controls="event-log">Hide Event Log</button>
-        <button id="toggle-build-queue" class="ui-button" type="button" aria-pressed="true" aria-controls="build-queue">Hide Build Queue</button>
+        <button id="toggle-buildables" class="ui-button" type="button" aria-pressed="true" aria-controls="buildables-list">Buildables</button>
+        <button id="toggle-inventory" class="ui-button" type="button" aria-pressed="true" aria-controls="inventory-list">Inventory</button>
+        <button id="toggle-event-log" class="ui-button" type="button" aria-pressed="true" aria-controls="event-log">Event Log</button>
+        <button id="toggle-build-queue" class="ui-button" type="button" aria-pressed="true" aria-controls="build-queue">Build Queue</button>
       </div>
       <div class="hotbar" id="hotbar"></div>
       <div class="event-log" id="event-log"></div>


### PR DESCRIPTION
## Summary
- replace the HUD banner with links to Open Source Ecology and an about panel describing the stranded truck scenario
- add dedicated vitals spans and an about toggle that keeps the story copy accessible without re-rendering the HUD every tick
- restyle and relabel the overlay toggle buttons so they sit in a single row and keep their labels while reflecting hidden state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e463b22ff8832380c333fc190937e2