### PR TITLE
Fix mobile overlay toggle button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,8 +88,16 @@
         .inventory-list,
         .event-log,
         .build-queue { height:auto; max-height:clamp(140px, 24vh, 200px); }
-        .overlay-toggle-group { align-items:stretch; }
-        .overlay-toggle-group .ui-button { width:100%; }
+        .overlay-toggle-group {
+          align-items:center;
+          flex-wrap:nowrap;
+          overflow-x:auto;
+          gap:6px;
+        }
+        .overlay-toggle-group .ui-button {
+          flex:1 0 auto;
+          white-space:nowrap;
+        }
         .event-log { order:4; }
         .build-queue { order:5; }
         .hotbar { bottom:12px; left:50%; transform:translateX(-50%); }


### PR DESCRIPTION
## Summary
- keep overlay toggle buttons in a single row on small screens by adjusting flex behavior
- allow horizontal scrolling to avoid wrapping while maintaining readability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e475bfb04c8323b128e5127426ff74