### PR TITLE
Allow world generation to expand in all directions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,7 @@ Use this document to orient code-generating agents.
 - **Code**: MIT.
 - **OSE blueprint-derived content**: include attributions (CC-BY-SA 4.0) in `docs/` and in-game blueprint viewer.
 
+## Notes for Future Agents
+- The world map now expands in every direction. `WorldState` includes a `bounds` object (min/max tile coordinates) so systems can convert between tile and pixel space without assuming `(0,0)` is fixed at the top-left. Use the helper methods in `GameScene` (e.g., `worldToPixelCenterX/Y`) or similar math when adding new renderables or input handlers.
+- After finishing a task, please add any helpful observations to this file **and** keep this reminder so the habit continues for future contributors.
+

--- a/index.html
+++ b/index.html
@@ -54,6 +54,24 @@
       .inventory-item.item { background:#1a1a2a; border:1px solid #46a; }
       .inventory-name { font-size:12px; }
       .inventory-count { font-size:11px; color:#aaa; font-weight:bold; }
+      .tech-tree { position:fixed; top:96px; right:228px; width:260px; max-height:360px; background:#1118; border:1px solid #333; border-radius:8px; overflow-y:auto; padding:10px; }
+      .tech-tier { background:#0e161b; border:1px solid #1f2a33; border-radius:8px; padding:10px 12px; margin-bottom:10px; box-shadow:0 2px 6px #0006; }
+      .tech-tier:last-of-type { margin-bottom:0; }
+      .tech-tier-header { display:flex; flex-direction:column; gap:2px; margin-bottom:8px; }
+      .tech-tier-rank { font-size:11px; text-transform:uppercase; letter-spacing:0.08em; color:#7bd; }
+      .tech-tier-title { font-size:16px; margin:0; color:#f0f4f6; }
+      .tech-tier-tagline { margin:0; font-size:12px; color:#9fb6c5; }
+      .tech-tier-section { margin-bottom:8px; }
+      .tech-tier-section:last-of-type { margin-bottom:0; }
+      .tech-tier-section-title { margin:0 0 4px 0; font-size:12px; text-transform:uppercase; letter-spacing:0.06em; color:#94d0ff; }
+      .tech-tier-list { margin:0; padding-left:18px; font-size:12px; color:#cfd8df; line-height:1.5; }
+      .tech-tier-list li { margin-bottom:2px; }
+      .tech-tier-list li:last-of-type { margin-bottom:0; }
+      .tech-tier-notes { margin-top:8px; border-top:1px solid #1f2a33; padding-top:8px; }
+      .tech-tier-note { margin:0 0 4px 0; font-size:12px; color:#cfd8df; }
+      .tech-tier-note:last-of-type { margin-bottom:0; }
+      .tech-tier-note-label { font-weight:600; color:#94d0ff; }
+      .tech-tier-note-text { color:#d8e2ea; }
       .slot-count { font-size:10px; color:#aaa; margin-top:2px; }
       .slot-label { font-size:12px; }
       .overlay-hidden { display:none !important; }
@@ -66,7 +84,7 @@
       #mode-toggle[data-mode='move'] { background:#1a3820aa; border-color:#3a6a46; }
       #mode-toggle[data-mode='build'] { background:#38201aaa; border-color:#6a463a; }
       @media (max-width: 900px) {
-        .buildables-list, .inventory-list { width: min(240px, 90vw); }
+        .buildables-list, .inventory-list, .tech-tree { width: min(260px, 90vw); }
         .event-log { width: min(280px, 90vw); height: 160px; }
         .build-queue { width: min(280px, 90vw); }
         .hotbar { gap:6px; padding:6px 10px; }
@@ -78,6 +96,7 @@
         #ui-overlay > .hud,
         #ui-overlay > .buildables-list,
         #ui-overlay > .inventory-list,
+        #ui-overlay > .tech-tree,
         #ui-overlay > .event-log,
         #ui-overlay > .build-queue,
         #ui-overlay > .overlay-toggle-group { position:static; width:min(480px, 94vw); max-width:94vw; transform:none; left:auto; right:auto; }
@@ -86,8 +105,9 @@
         .hud-links { justify-content:center; }
         .buildables-list,
         .inventory-list,
+        .tech-tree,
         .event-log,
-        .build-queue { height:auto; max-height:clamp(140px, 24vh, 200px); }
+        .build-queue { height:auto; max-height:clamp(140px, 24vh, 220px); }
         .overlay-toggle-group {
           align-items:center;
           flex-wrap:nowrap;
@@ -98,8 +118,9 @@
           flex:1 0 auto;
           white-space:nowrap;
         }
-        .event-log { order:4; }
-        .build-queue { order:5; }
+        .tech-tree { order:4; }
+        .event-log { order:5; }
+        .build-queue { order:6; }
         .hotbar { bottom:12px; left:50%; transform:translateX(-50%); }
         #mode-toggle { bottom:calc(12px + 64px + 12px); }
       }
@@ -129,12 +150,14 @@
       <div id="overlay-toggle-group" class="overlay-toggle-group">
         <button id="toggle-buildables" class="ui-button" type="button" aria-pressed="true" aria-controls="buildables-list">Buildables</button>
         <button id="toggle-inventory" class="ui-button" type="button" aria-pressed="true" aria-controls="inventory-list">Inventory</button>
+        <button id="toggle-tech-tree" class="ui-button" type="button" aria-pressed="true" aria-controls="tech-tree">Tech Tree</button>
         <button id="toggle-event-log" class="ui-button" type="button" aria-pressed="true" aria-controls="event-log">Event Log</button>
         <button id="toggle-build-queue" class="ui-button" type="button" aria-pressed="true" aria-controls="build-queue">Build Queue</button>
       </div>
       <div class="hotbar" id="hotbar"></div>
       <div class="event-log" id="event-log"></div>
       <div class="buildables-list" id="buildables-list"></div>
+      <div class="tech-tree" id="tech-tree"></div>
       <div class="build-queue" id="build-queue"></div>
       <div class="inventory-list" id="inventory-list"></div>
       <button id="mode-toggle" class="ui-button" type="button" data-mode="build" aria-pressed="false">Build Mode</button>

--- a/src/data/techTree.ts
+++ b/src/data/techTree.ts
@@ -1,0 +1,197 @@
+export type TechTierSection = {
+  label: string;
+  items: string[];
+};
+
+export type TechTierNote = {
+  label: string;
+  text: string;
+};
+
+export type TechTier = {
+  id: string;
+  tier: string;
+  name: string;
+  tagline?: string;
+  sections: TechTierSection[];
+  notes?: TechTierNote[];
+};
+
+export const techTree: TechTier[] = [
+  {
+    id: 'tier0',
+    tier: 'Tier 0',
+    name: 'Hand tools & camp',
+    tagline: 'Bootstrap essentials for your first camp.',
+    sections: [
+      {
+        label: 'Buildings',
+        items: ['Workbench (hand crafting)', 'Drying Rack']
+      },
+      {
+        label: 'Base resources',
+        items: ['Soil', 'Sand', 'Clay', 'Wood', 'Scrap Metal', 'Water']
+      },
+      {
+        label: 'Parts unlocked',
+        items: ['Fastener Pack', 'Frame Beam (basic)']
+      }
+    ],
+    notes: [
+      {
+        label: 'Goal',
+        text: 'Craft enough parts to place the first real shop.'
+      }
+    ]
+  },
+  {
+    id: 'tier1',
+    tier: 'Tier 1',
+    name: 'Workshop',
+    tagline: 'Fabrication bootstrap.',
+    sections: [
+      {
+        label: 'Buildings',
+        items: ['Machine Shop (cuts/holes)', 'Kiln (low-temp firing)']
+      },
+      {
+        label: 'Sub-components unlocked',
+        items: [
+          'Fastener Pack (bolts, nuts, washers)',
+          'Frame Beam + Gusset Plate',
+          'Bearing Unit (bearing + housing)',
+          'Shaft Unit (cut shaft + keyway)'
+        ]
+      }
+    ],
+    notes: [
+      {
+        label: 'Goal',
+        text: 'Assemble Power Cube (your first energy hub).'
+      }
+    ]
+  },
+  {
+    id: 'tier2',
+    tier: 'Tier 2',
+    name: 'Power & Hydraulics',
+    sections: [
+      {
+        label: 'Buildings',
+        items: ['Hydraulics Bench (hoses/fittings)', 'Fuel Station']
+      },
+      {
+        label: 'Machines',
+        items: ['Power Cube (hydraulic power producer)']
+      },
+      {
+        label: 'Sub-components unlocked',
+        items: [
+          'Hydraulic Pack (pump, reservoir, hoses)',
+          'Quick-Attach Plate (universal mount)',
+          'Control Box (basic) (switches/relays)'
+        ]
+      }
+    ],
+    notes: [
+      {
+        label: 'Goal loop',
+        text: 'Route hydraulic power to consumers.'
+      }
+    ]
+  },
+  {
+    id: 'tier3',
+    tier: 'Tier 3',
+    name: 'Earth & Habitat',
+    tagline: 'First product loop.',
+    sections: [
+      {
+        label: 'Buildings',
+        items: ['Soil Processor (sieve + moisture mix)', 'Drying Yard']
+      },
+      {
+        label: 'Machines',
+        items: ['CEB Press (The Liberator)']
+      },
+      {
+        label: 'Products',
+        items: ['Compressed Earth Bricks (CEB)']
+      }
+    ],
+    notes: [
+      {
+        label: 'Loop',
+        text: 'Soil + water → CEB; place walls → progression unlocks.'
+      }
+    ]
+  },
+  {
+    id: 'tier4',
+    tier: 'Tier 4',
+    name: 'Mobility & Handling',
+    sections: [
+      {
+        label: 'Buildings',
+        items: ['Wheel Shop (rims/tires)', 'Welding Bay']
+      },
+      {
+        label: 'Machines',
+        items: ['LifeTrac (tractor)', 'Loader Frame']
+      },
+      {
+        label: 'Sub-components',
+        items: ['Wheel Unit (hub + tire)', 'Hydraulic Cylinder (assembled from seals + tube)']
+      }
+    ],
+    notes: [
+      {
+        label: 'Loop',
+        text: 'LifeTrac moves materials faster; can power attachments via Power Cube bay.'
+      }
+    ]
+  },
+  {
+    id: 'tier5',
+    tier: 'Tier 5',
+    name: 'Metal Fabrication',
+    tagline: 'Faster parts.',
+    sections: [
+      {
+        label: 'Buildings',
+        items: ['CNC Torch Table', 'Foundry (basic) (ingot → plate/rod)']
+      },
+      {
+        label: 'Products',
+        items: ['Steel Plate', 'Angle Iron', 'Cut Parts']
+      }
+    ],
+    notes: [
+      {
+        label: 'Loop',
+        text: 'Unlocks cheaper/faster Frame Beams, Gussets, Quick-Attach.'
+      }
+    ]
+  },
+  {
+    id: 'tier6',
+    tier: 'Tier 6',
+    name: 'Sawmill & Seed Eco-Home Starter',
+    sections: [
+      {
+        label: 'Buildings / Machines',
+        items: ['Sawmill', 'Seed Eco-Home Kit']
+      },
+      {
+        label: 'Products',
+        items: ['Lumber sets', 'Panels', 'Doors/Frames']
+      }
+    ],
+    notes: [
+      {
+        label: 'Loop',
+        text: 'Bricks + lumber → livable starter house.'
+      }
+    ]
+  }
+];

--- a/src/ecs/components.ts
+++ b/src/ecs/components.ts
@@ -15,7 +15,7 @@ export type Player = {
 
 export type ResourceNode = {
   pos: Position;
-  type: string; // 'clay', 'water', 'stone'
+  type: string; // 'soil', 'sand', 'clay', 'wood', 'scrap_metal', 'water'
   amount: number;
   maxAmount: number;
 };
@@ -40,6 +40,12 @@ export type WorldState = {
   gridSize: number;
   width: number;
   height: number;
+  bounds: {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+  };
   placed: PlacedEntity[];
   player: Player;
   resources: ResourceNode[];

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -2,23 +2,35 @@
 import Phaser from 'phaser';
 import type { WorldState } from '../ecs/components';
 import { hydraulicsSystem, craftingSystem } from '../ecs/systems';
+import { techTree } from '../data/techTree';
+
+type ResourceKind = 'soil' | 'sand' | 'clay' | 'wood' | 'scrap_metal' | 'water';
 
 export class GameScene extends Phaser.Scene {
   state: WorldState = {
     gridSize: 32,
-    width: 20,
-    height: 12,
+    width: 16,
+    height: 16,
+    bounds: { minX: 0, minY: 0, maxX: 15, maxY: 15 },
     placed: [],
     player: { pos: { x: 15, y: 10 }, health: 100, thirst: 100, energy: 100 },
     resources: [],
-    inventory: { brick_ceb: 0, clay: 0, water: 0, stone: 0 },
+    inventory: {
+      brick_ceb: 0,
+      soil: 0,
+      sand: 0,
+      clay: 0,
+      wood: 0,
+      scrap_metal: 0,
+      water: 0
+    },
     selected: 'power_cube',
     buildables: [
       {
         id: 'power_cube',
         name: 'Power Cube',
         description: 'Provides hydraulic power to adjacent machines',
-        requirements: { stone: 10, clay: 5 },
+        requirements: { scrap_metal: 10, clay: 8, wood: 6 },
         buildTime: 30,
         unlocked: true
       },
@@ -26,7 +38,7 @@ export class GameScene extends Phaser.Scene {
         id: 'ceb_press',
         name: 'CEB Press',
         description: 'Compresses earth into building blocks',
-        requirements: { stone: 20, clay: 15, brick_ceb: 5 },
+        requirements: { scrap_metal: 25, clay: 20, sand: 12 },
         buildTime: 120,
         unlocked: false
       },
@@ -34,7 +46,7 @@ export class GameScene extends Phaser.Scene {
         id: 'water_well',
         name: 'Water Well',
         description: 'Extracts water from underground',
-        requirements: { stone: 15, clay: 10 },
+        requirements: { wood: 12, soil: 18, scrap_metal: 6 },
         buildTime: 60,
         unlocked: true
       },
@@ -42,7 +54,7 @@ export class GameScene extends Phaser.Scene {
         id: 'storage_shed',
         name: 'Storage Shed',
         description: 'Increases inventory capacity',
-        requirements: { stone: 25, clay: 20 },
+        requirements: { wood: 24, soil: 20, sand: 14 },
         buildTime: 90,
         unlocked: true
       }
@@ -55,6 +67,11 @@ export class GameScene extends Phaser.Scene {
   private buildablesList!: HTMLDivElement;
   private buildQueue!: HTMLDivElement;
   private inventoryList!: HTMLDivElement;
+  private techTreePanel?: HTMLDivElement;
+  private gridGraphics?: Phaser.GameObjects.Graphics;
+  private generatedChunks = new Set<string>();
+  private ensuredSpawnResources = false;
+  private readonly chunkSize = 16;
   private overlayToggles: { button: HTMLButtonElement; element: HTMLElement; name: string }[] = [];
   private modeToggleButton?: HTMLButtonElement;
   private hudHealthValue?: HTMLSpanElement;
@@ -67,34 +84,51 @@ export class GameScene extends Phaser.Scene {
   private playerSprite?: Phaser.GameObjects.Container;
   private playerDirection: 'up' | 'down' | 'left' | 'right' = 'right';
 
+  private worldToPixelX(tileX: number) {
+    return (tileX - this.state.bounds.minX) * this.state.gridSize;
+  }
+
+  private worldToPixelY(tileY: number) {
+    return (tileY - this.state.bounds.minY) * this.state.gridSize;
+  }
+
+  private worldToPixelCenterX(tileX: number) {
+    return this.worldToPixelX(tileX) + this.state.gridSize / 2;
+  }
+
+  private worldToPixelCenterY(tileY: number) {
+    return this.worldToPixelY(tileY) + this.state.gridSize / 2;
+  }
+
+  private pixelToTileX(pixelX: number) {
+    return Math.floor(pixelX / this.state.gridSize) + this.state.bounds.minX;
+  }
+
+  private pixelToTileY(pixelY: number) {
+    return Math.floor(pixelY / this.state.gridSize) + this.state.bounds.minY;
+  }
+
   constructor() {
     super('game');
   }
 
   preload() {
     this.load.image('tiles', '/tilesets/placeholder-tiles.png');
-    this.load.json('map', '/maps/desert-map.json');
   }
 
   create() {
-    const map = this.cache.json.get('map') as { width:number; height:number; tileSize:number; };
-    this.state.width = map.width;
-    this.state.height = map.height;
-    this.state.gridSize = map.tileSize;
-
     this.cameras.main.setBackgroundColor(0x0b0f12);
     this.cameras.main.setZoom(1.5);
-    this.cameras.main.centerOn(map.width * map.tileSize / 2, map.height * map.tileSize / 2);
+    this.cameras.main.centerOn(
+      this.worldToPixelCenterX(this.state.player.pos.x),
+      this.worldToPixelCenterY(this.state.player.pos.y)
+    );
 
-    // draw simple grid
-    const g = this.add.graphics();
-    g.lineStyle(1, 0x28323a, 1);
-    for (let x = 0; x <= map.width; x++) {
-      g.lineBetween(x * map.tileSize, 0, x * map.tileSize, map.height * map.tileSize);
-    }
-    for (let y = 0; y <= map.height; y++) {
-      g.lineBetween(0, y * map.tileSize, map.width * map.tileSize, y * map.tileSize);
-    }
+    this.gridGraphics = this.add.graphics();
+    this.gridGraphics.setDepth(-1);
+    this.gridGraphics.lineStyle(1, 0x28323a, 1);
+
+    this.initializeWorld();
 
     this.setupPointerInput();
 
@@ -131,6 +165,9 @@ export class GameScene extends Phaser.Scene {
     // inventory list
     this.buildInventoryList();
 
+    // tech tree panel
+    this.buildTechTreePanel();
+
     this.setupOverlayToggles();
     this.setupInteractionModeToggle();
 
@@ -138,7 +175,6 @@ export class GameScene extends Phaser.Scene {
 
     // entity visuals container
     this.add.layer();
-    this.initializeResources();
     this.redrawEntities();
     this.redrawPlayer();
     
@@ -235,9 +271,10 @@ export class GameScene extends Phaser.Scene {
   private setupPointerInput() {
     this.input.on('pointerdown', (p: Phaser.Input.Pointer) => {
       const world = p.positionToCamera(this.cameras.main) as Phaser.Math.Vector2;
-      const gx = Math.floor(world.x / this.state.gridSize);
-      const gy = Math.floor(world.y / this.state.gridSize);
-      if (!this.isWithinBounds(gx, gy)) return;
+      const gx = this.pixelToTileX(world.x);
+      const gy = this.pixelToTileY(world.y);
+      if (!this.ensureTileInWorld(gx, gy)) return;
+      this.ensureSurroundingChunks(gx, gy, 1);
 
       const isPlayerTile =
         gx === this.state.player.pos.x && gy === this.state.player.pos.y;
@@ -309,7 +346,7 @@ export class GameScene extends Phaser.Scene {
       itemDiv.className = `buildable-item ${canBuild ? 'available' : 'unavailable'}`;
       
       const requirements = Object.entries(item.requirements)
-        .map(([resource, amount]) => `${resource}: ${amount}`)
+        .map(([resource, amount]) => `${this.formatResourceLabel(resource)}: ${amount}`)
         .join(', ');
       
       itemDiv.innerHTML = `
@@ -376,6 +413,94 @@ export class GameScene extends Phaser.Scene {
     this.updateBuildQueue();
   }
 
+  private buildTechTreePanel() {
+    const panel = document.getElementById('tech-tree');
+    if (panel instanceof HTMLDivElement) {
+      this.techTreePanel = panel;
+      this.renderTechTree();
+    }
+  }
+
+  private renderTechTree() {
+    if (!this.techTreePanel) return;
+
+    this.techTreePanel.innerHTML = '';
+
+    for (const tier of techTree) {
+      const tierSection = document.createElement('section');
+      tierSection.className = 'tech-tier';
+
+      const header = document.createElement('header');
+      header.className = 'tech-tier-header';
+
+      const tierLabel = document.createElement('span');
+      tierLabel.className = 'tech-tier-rank';
+      tierLabel.textContent = tier.tier;
+      header.appendChild(tierLabel);
+
+      const title = document.createElement('h3');
+      title.className = 'tech-tier-title';
+      title.textContent = tier.name;
+      header.appendChild(title);
+
+      if (tier.tagline) {
+        const tagline = document.createElement('p');
+        tagline.className = 'tech-tier-tagline';
+        tagline.textContent = tier.tagline;
+        header.appendChild(tagline);
+      }
+
+      tierSection.appendChild(header);
+
+      for (const section of tier.sections) {
+        const sectionEl = document.createElement('div');
+        sectionEl.className = 'tech-tier-section';
+
+        const sectionTitle = document.createElement('h4');
+        sectionTitle.className = 'tech-tier-section-title';
+        sectionTitle.textContent = section.label;
+        sectionEl.appendChild(sectionTitle);
+
+        const list = document.createElement('ul');
+        list.className = 'tech-tier-list';
+        for (const item of section.items) {
+          const listItem = document.createElement('li');
+          listItem.textContent = item;
+          list.appendChild(listItem);
+        }
+        sectionEl.appendChild(list);
+
+        tierSection.appendChild(sectionEl);
+      }
+
+      if (tier.notes && tier.notes.length > 0) {
+        const notesWrapper = document.createElement('div');
+        notesWrapper.className = 'tech-tier-notes';
+
+        for (const note of tier.notes) {
+          const noteEl = document.createElement('p');
+          noteEl.className = 'tech-tier-note';
+
+          const noteLabel = document.createElement('span');
+          noteLabel.className = 'tech-tier-note-label';
+          noteLabel.textContent = `${note.label}:`;
+          noteEl.appendChild(noteLabel);
+
+          const noteText = document.createElement('span');
+          noteText.className = 'tech-tier-note-text';
+          noteText.textContent = ` ${note.text}`;
+          noteEl.appendChild(noteText);
+
+          notesWrapper.appendChild(noteEl);
+        }
+
+        tierSection.appendChild(notesWrapper);
+      }
+
+      this.techTreePanel.appendChild(tierSection);
+    }
+  }
+
   private updateBuildQueue() {
     this.buildQueue.innerHTML = '';
     
@@ -416,9 +541,12 @@ export class GameScene extends Phaser.Scene {
     this.inventoryList.innerHTML = '';
     
     const allItems = [
+      { id: 'soil', name: 'Soil', type: 'resource' },
+      { id: 'sand', name: 'Sand', type: 'resource' },
       { id: 'clay', name: 'Clay', type: 'resource' },
+      { id: 'wood', name: 'Wood', type: 'resource' },
+      { id: 'scrap_metal', name: 'Scrap Metal', type: 'resource' },
       { id: 'water', name: 'Water', type: 'resource' },
-      { id: 'stone', name: 'Stone', type: 'resource' },
       { id: 'brick_ceb', name: 'Bricks', type: 'resource' },
       { id: 'power_cube', name: 'Power Cube', type: 'item' },
       { id: 'ceb_press', name: 'CEB Press', type: 'item' },
@@ -443,7 +571,7 @@ export class GameScene extends Phaser.Scene {
   private cancelBuilding(index: number) {
     if (index >= 0 && index < this.state.buildQueue.length) {
       const item = this.state.buildQueue[index];
-      
+
       // Refund resources
       const buildable = this.state.buildables.find(b => b.id === item.id);
       if (buildable) {
@@ -451,33 +579,216 @@ export class GameScene extends Phaser.Scene {
           this.state.inventory[resource] = (this.state.inventory[resource] || 0) + amount;
         }
       }
-      
+
       this.state.buildQueue.splice(index, 1);
       this.addEvent(`Cancelled building ${item.name}`);
       this.updateAllUI();
     }
   }
 
-  private initializeResources() {
-    const map = this.cache.json.get('map') as any;
-    const resourceLayer = map.layers.find((l: any) => l.name === 'resources');
-    
-    if (resourceLayer) {
-      for (let y = 0; y < map.height; y++) {
-        for (let x = 0; x < map.width; x++) {
-          const resourceType = resourceLayer.data[y][x];
-          if (resourceType > 0) {
-            const resourceTypes = ['', 'clay', 'stone', 'water'];
-            this.state.resources.push({
-              pos: { x, y },
-              type: resourceTypes[resourceType],
-              amount: 50, // Start with 50 units
-              maxAmount: 50
-            });
-          }
+  private initializeWorld() {
+    this.generatedChunks.clear();
+    this.ensuredSpawnResources = false;
+    this.state.resources = [];
+    this.state.width = this.chunkSize;
+    this.state.height = this.chunkSize;
+    this.state.bounds = {
+      minX: 0,
+      minY: 0,
+      maxX: this.chunkSize - 1,
+      maxY: this.chunkSize - 1
+    };
+
+    this.ensureSurroundingChunks(this.state.player.pos.x, this.state.player.pos.y, 1);
+    this.redrawGrid();
+  }
+
+  private ensureSurroundingChunks(tileX: number, tileY: number, chunkRadius: number) {
+    const centerChunkX = Math.floor(tileX / this.chunkSize);
+    const centerChunkY = Math.floor(tileY / this.chunkSize);
+
+    for (let cx = centerChunkX - chunkRadius; cx <= centerChunkX + chunkRadius; cx++) {
+      for (let cy = centerChunkY - chunkRadius; cy <= centerChunkY + chunkRadius; cy++) {
+        this.ensureChunk(cx, cy);
+      }
+    }
+  }
+
+  private ensureTileInWorld(x: number, y: number) {
+    this.ensureChunkForTile(x, y);
+    return this.isWithinBounds(x, y);
+  }
+
+  private ensureChunkForTile(tileX: number, tileY: number) {
+    const chunkX = Math.floor(tileX / this.chunkSize);
+    const chunkY = Math.floor(tileY / this.chunkSize);
+    this.ensureChunk(chunkX, chunkY);
+  }
+
+  private ensureChunk(chunkX: number, chunkY: number) {
+    const key = this.getChunkKey(chunkX, chunkY);
+    if (this.generatedChunks.has(key)) return;
+
+    this.generatedChunks.add(key);
+    const minTileX = chunkX * this.chunkSize;
+    const minTileY = chunkY * this.chunkSize;
+    const maxTileX = minTileX + this.chunkSize - 1;
+    const maxTileY = minTileY + this.chunkSize - 1;
+    const boundsChanged = this.expandWorldToIncludeArea(minTileX, minTileY, maxTileX, maxTileY);
+    this.generateChunk(chunkX, chunkY);
+    this.redrawEntities();
+    if (boundsChanged) {
+      this.redrawPlayer();
+    }
+  }
+
+  private expandWorldToIncludeArea(minX: number, minY: number, maxX: number, maxY: number) {
+    const bounds = this.state.bounds;
+    const newMinX = Math.min(bounds.minX, minX);
+    const newMinY = Math.min(bounds.minY, minY);
+    const newMaxX = Math.max(bounds.maxX, maxX);
+    const newMaxY = Math.max(bounds.maxY, maxY);
+
+    if (
+      newMinX === bounds.minX &&
+      newMinY === bounds.minY &&
+      newMaxX === bounds.maxX &&
+      newMaxY === bounds.maxY
+    ) {
+      return false;
+    }
+
+    this.state.bounds = { minX: newMinX, minY: newMinY, maxX: newMaxX, maxY: newMaxY };
+    this.state.width = newMaxX - newMinX + 1;
+    this.state.height = newMaxY - newMinY + 1;
+    this.redrawGrid();
+    return true;
+  }
+
+  private redrawGrid() {
+    if (!this.gridGraphics) return;
+
+    const widthPx = this.state.width * this.state.gridSize;
+    const heightPx = this.state.height * this.state.gridSize;
+
+    this.gridGraphics.clear();
+    this.gridGraphics.lineStyle(1, 0x28323a, 1);
+
+    for (let x = 0; x <= this.state.width; x++) {
+      const px = x * this.state.gridSize;
+      this.gridGraphics.lineBetween(px, 0, px, heightPx);
+    }
+
+    for (let y = 0; y <= this.state.height; y++) {
+      const py = y * this.state.gridSize;
+      this.gridGraphics.lineBetween(0, py, widthPx, py);
+    }
+  }
+
+  private generateChunk(chunkX: number, chunkY: number) {
+    const resourcePool: ResourceKind[] = [
+      'soil', 'soil', 'soil',
+      'sand', 'sand',
+      'clay', 'clay',
+      'wood', 'wood',
+      'scrap_metal',
+      'water'
+    ];
+
+    const rng = this.createChunkRandom(chunkX, chunkY);
+    const startX = chunkX * this.chunkSize;
+    const startY = chunkY * this.chunkSize;
+
+    for (let lx = 0; lx < this.chunkSize; lx++) {
+      for (let ly = 0; ly < this.chunkSize; ly++) {
+        const worldX = startX + lx;
+        const worldY = startY + ly;
+        const roll = rng();
+
+        if (roll < 0.25) {
+          const resourceType = resourcePool[Math.floor(rng() * resourcePool.length)];
+          const richness = 35 + Math.floor(rng() * 55);
+          this.addResourceNode(worldX, worldY, resourceType, richness);
+        } else if (roll < 0.32) {
+          // Low chance to sprinkle extra soil pockets for building
+          const richness = 45 + Math.floor(rng() * 40);
+          this.addResourceNode(worldX, worldY, 'soil', richness);
         }
       }
     }
+
+    const spawnChunkX = Math.floor(this.state.player.pos.x / this.chunkSize);
+    const spawnChunkY = Math.floor(this.state.player.pos.y / this.chunkSize);
+
+    if (!this.ensuredSpawnResources && chunkX === spawnChunkX && chunkY === spawnChunkY) {
+      this.seedSpawnResources();
+      this.ensuredSpawnResources = true;
+    }
+  }
+
+  private seedSpawnResources() {
+    const spawn = this.state.player.pos;
+    const guaranteed: { type: ResourceKind; dx: number; dy: number; richness: number }[] = [
+      { type: 'soil', dx: -1, dy: 0, richness: 80 },
+      { type: 'sand', dx: 1, dy: 0, richness: 70 },
+      { type: 'clay', dx: 0, dy: -1, richness: 70 },
+      { type: 'wood', dx: 0, dy: 1, richness: 65 },
+      { type: 'scrap_metal', dx: 2, dy: 0, richness: 60 },
+      { type: 'water', dx: 0, dy: 2, richness: 60 }
+    ];
+
+    for (const { type, dx, dy, richness } of guaranteed) {
+      const tileX = spawn.x + dx;
+      const tileY = spawn.y + dy;
+      this.addResourceNode(tileX, tileY, type, richness, true);
+    }
+  }
+
+  private addResourceNode(
+    tileX: number,
+    tileY: number,
+    type: ResourceKind,
+    amount: number,
+    overwrite = false
+  ) {
+    const existing = this.state.resources.find(r => r.pos.x === tileX && r.pos.y === tileY);
+
+    if (existing) {
+      if (overwrite) {
+        existing.type = type;
+        existing.amount = amount;
+        existing.maxAmount = Math.max(existing.maxAmount, amount);
+      }
+      return;
+    }
+
+    this.state.resources.push({
+      pos: { x: tileX, y: tileY },
+      type,
+      amount,
+      maxAmount: amount
+    });
+  }
+
+  private getChunkKey(x: number, y: number) {
+    return `${x}:${y}`;
+  }
+
+  private createChunkRandom(chunkX: number, chunkY: number) {
+    const x = chunkX | 0;
+    const y = chunkY | 0;
+    let seed = (Math.imul(x, 374761393) ^ Math.imul(y, 668265263)) >>> 0;
+    if (seed === 0) {
+      seed = 0x9e3779b9;
+    }
+    let state = seed;
+    return () => {
+      state += 0x6D2B79F5;
+      let t = state;
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
   }
 
   private redrawEntities() {
@@ -494,10 +805,10 @@ export class GameScene extends Phaser.Scene {
         storage_shed: 0x8a6     // Orange
       };
       const color = colors[e.id as keyof typeof colors] || 0x666;
-      
+
       const entitySprite = this.add.circle(
-        e.pos.x * this.state.gridSize + 16,
-        e.pos.y * this.state.gridSize + 16,
+        this.worldToPixelCenterX(e.pos.x),
+        this.worldToPixelCenterY(e.pos.y),
         12,
         color
       );
@@ -507,13 +818,20 @@ export class GameScene extends Phaser.Scene {
     // Draw resources
     for (const resource of this.state.resources) {
       if (resource.amount > 0) {
-        const colors = { clay: 0x8B4513, stone: 0x696969, water: 0x4169E1 };
+        const colors = {
+          soil: 0x8B5A2B,
+          sand: 0xC2B280,
+          clay: 0xA0522D,
+          wood: 0x4F7942,
+          scrap_metal: 0x7A8A99,
+          water: 0x4169E1
+        };
         const color = colors[resource.type as keyof typeof colors] || 0xFFFFFF;
         const size = Math.max(4, (resource.amount / resource.maxAmount) * 12);
-        
+
         const resourceSprite = this.add.circle(
-          resource.pos.x * this.state.gridSize + 16,
-          resource.pos.y * this.state.gridSize + 16,
+          this.worldToPixelCenterX(resource.pos.x),
+          this.worldToPixelCenterY(resource.pos.y),
           size,
           color
         );
@@ -528,14 +846,14 @@ export class GameScene extends Phaser.Scene {
     const newX = this.state.player.pos.x + dx;
     const newY = this.state.player.pos.y + dy;
 
-    // Check bounds
-    if (newX >= 0 && newX < this.state.width && newY >= 0 && newY < this.state.height) {
-      this.updatePlayerDirection(dx, dy);
-      this.state.player.pos.x = newX;
-      this.state.player.pos.y = newY;
-      this.redrawPlayer();
-      this.collectResource();
-    }
+    if (!this.ensureTileInWorld(newX, newY)) return;
+
+    this.updatePlayerDirection(dx, dy);
+    this.state.player.pos.x = newX;
+    this.state.player.pos.y = newY;
+    this.ensureSurroundingChunks(newX, newY, 1);
+    this.redrawPlayer();
+    this.collectResource();
   }
 
   private findResourceAt(x: number, y: number) {
@@ -544,6 +862,7 @@ export class GameScene extends Phaser.Scene {
 
   private collectResource() {
     const playerPos = this.state.player.pos;
+    this.ensureChunkForTile(playerPos.x, playerPos.y);
     const resource = this.findResourceAt(playerPos.x, playerPos.y);
 
     if (!resource) return false;
@@ -552,12 +871,13 @@ export class GameScene extends Phaser.Scene {
     resource.amount -= collected;
     this.state.inventory[resource.type] = (this.state.inventory[resource.type] || 0) + collected;
 
-    this.addEvent(`Collected ${collected} ${resource.type} (${resource.amount} remaining)`);
+    const label = this.formatResourceLabel(resource.type);
+    this.addEvent(`Collected ${collected} ${label} (${resource.amount} remaining)`);
 
     // If resource is depleted, remove it
     if (resource.amount <= 0) {
       this.state.resources = this.state.resources.filter(r => r !== resource);
-      this.addEvent(`${resource.type} deposit depleted`);
+      this.addEvent(`${label} deposit depleted`);
     }
 
     this.redrawEntities();
@@ -576,8 +896,8 @@ export class GameScene extends Phaser.Scene {
   }
 
   private redrawPlayer() {
-    const x = this.state.player.pos.x * this.state.gridSize + this.state.gridSize / 2;
-    const y = this.state.player.pos.y * this.state.gridSize + this.state.gridSize / 2;
+    const x = this.worldToPixelCenterX(this.state.player.pos.x);
+    const y = this.worldToPixelCenterY(this.state.player.pos.y);
 
     if (!this.playerSprite) {
       const container = this.add.container(x, y);
@@ -749,7 +1069,7 @@ export class GameScene extends Phaser.Scene {
   }
 
   private setMovementTarget(tileX: number, tileY: number) {
-    if (!this.isWithinBounds(tileX, tileY)) return;
+    if (!this.ensureTileInWorld(tileX, tileY)) return;
 
     const current = this.state.player.pos;
     if (current.x === tileX && current.y === tileY) {
@@ -766,16 +1086,23 @@ export class GameScene extends Phaser.Scene {
 
     while (cx !== tileX) {
       cx += stepX;
+      if (!this.ensureTileInWorld(cx, cy)) break;
       path.push({ x: cx, y: cy });
     }
 
     while (cy !== tileY) {
       cy += stepY;
+      if (!this.ensureTileInWorld(cx, cy)) break;
       path.push({ x: cx, y: cy });
     }
 
-    this.movementPath = path.filter(pos => this.isWithinBounds(pos.x, pos.y));
+    this.movementPath = path;
     this.movementAccum = 0;
+
+    if (path.length > 0) {
+      const last = path[path.length - 1];
+      this.ensureSurroundingChunks(last.x, last.y, 1);
+    }
   }
 
   private updateMovement(dt: number) {
@@ -794,6 +1121,7 @@ export class GameScene extends Phaser.Scene {
       this.updatePlayerDirection(next.x - currentX, next.y - currentY);
       this.state.player.pos.x = next.x;
       this.state.player.pos.y = next.y;
+      this.ensureSurroundingChunks(next.x, next.y, 1);
       moved = true;
     }
 
@@ -812,7 +1140,8 @@ export class GameScene extends Phaser.Scene {
       { name: 'Buildables', buttonId: 'toggle-buildables', targetSelector: '#buildables-list' },
       { name: 'Inventory', buttonId: 'toggle-inventory', targetSelector: '#inventory-list' },
       { name: 'Event Log', buttonId: 'toggle-event-log', targetSelector: '#event-log' },
-      { name: 'Build Queue', buttonId: 'toggle-build-queue', targetSelector: '#build-queue' }
+      { name: 'Build Queue', buttonId: 'toggle-build-queue', targetSelector: '#build-queue' },
+      { name: 'Tech Tree', buttonId: 'toggle-tech-tree', targetSelector: '#tech-tree' }
     ];
 
     this.overlayToggles = [];
@@ -875,7 +1204,19 @@ export class GameScene extends Phaser.Scene {
       : 'Tap tiles to place or remove builds. Tap to switch back to movement.';
   }
 
+  private formatResourceLabel(id: string) {
+    return id
+      .split('_')
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ');
+  }
+
   private isWithinBounds(x: number, y: number) {
-    return x >= 0 && y >= 0 && x < this.state.width && y < this.state.height;
+    return (
+      x >= this.state.bounds.minX &&
+      y >= this.state.bounds.minY &&
+      x <= this.state.bounds.maxX &&
+      y <= this.state.bounds.maxY
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add persistent world bounds to the game state plus tile/pixel helpers so rendering and input handle negative coordinates
- update chunk generation to cover tiles in every direction, seed spawn resources without clamping, and reposition sprites when bounds grow
- document the new bounds convention in AGENTS.md for future contributors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6d21c47e483238f4768327d9e86bb