### PR TITLE
Scale down SVG assets

### DIFF
--- a/public/images/desert-ground.svg
+++ b/public/images/desert-ground.svg
@@ -15,7 +15,9 @@
       <circle cx="44" cy="16" r="3" fill="#b7823d" opacity="0.32" />
     </pattern>
   </defs>
-  <rect width="256" height="256" fill="url(#duneRipples)" />
-  <path d="M0 92c24-8 48-6 72 4s48 10 72 2 48-6 72 4 48 10 72 2v152H0V92z" fill="#c69246" opacity="0.12" />
-  <path d="M0 176c18-6 36-6 54 2s36 8 54 2 36-6 54 2 36 8 54 2 36-6 54 2v72H0v-80z" fill="#a56d32" opacity="0.1" />
+  <g transform="translate(64 64) scale(0.5)">
+    <rect width="256" height="256" fill="url(#duneRipples)" />
+    <path d="M0 92c24-8 48-6 72 4s48 10 72 2 48-6 72 4 48 10 72 2v152H0V92z" fill="#c69246" opacity="0.12" />
+    <path d="M0 176c18-6 36-6 54 2s36 8 54 2 36-6 54 2 36 8 54 2 36-6 54 2v72H0v-80z" fill="#a56d32" opacity="0.1" />
+  </g>
 </svg>

--- a/public/images/items/ceb_press.svg
+++ b/public/images/items/ceb_press.svg
@@ -1,12 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="12" fill="#1b1f27" />
-  <g stroke="#0f141a" stroke-width="2" stroke-linejoin="round">
-    <rect x="14" y="18" width="36" height="12" rx="4" fill="#3e5d88" />
-    <rect x="18" y="28" width="28" height="18" rx="4" fill="#4f7cb2" />
-    <path d="M22 36h20" stroke="#a6c4e5" stroke-linecap="round" />
-    <rect x="22" y="12" width="20" height="8" rx="3" fill="#2c3f59" />
-    <rect x="24" y="44" width="16" height="8" rx="3" fill="#f4843d" />
+  <g transform="translate(16 16) scale(0.5)">
+    <rect width="64" height="64" rx="12" fill="#1b1f27" />
+    <g stroke="#0f141a" stroke-width="2" stroke-linejoin="round">
+      <rect x="14" y="18" width="36" height="12" rx="4" fill="#3e5d88" />
+      <rect x="18" y="28" width="28" height="18" rx="4" fill="#4f7cb2" />
+      <path d="M22 36h20" stroke="#a6c4e5" stroke-linecap="round" />
+      <rect x="22" y="12" width="20" height="8" rx="3" fill="#2c3f59" />
+      <rect x="24" y="44" width="16" height="8" rx="3" fill="#f4843d" />
+    </g>
+    <circle cx="24" cy="24" r="2.4" fill="#91b2d8" />
+    <circle cx="40" cy="24" r="2.4" fill="#91b2d8" />
   </g>
-  <circle cx="24" cy="24" r="2.4" fill="#91b2d8" />
-  <circle cx="40" cy="24" r="2.4" fill="#91b2d8" />
 </svg>

--- a/public/images/items/power_cube.svg
+++ b/public/images/items/power_cube.svg
@@ -1,11 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="12" fill="#141a24" />
-  <g stroke="#0f1218" stroke-width="2" stroke-linejoin="round">
-    <path d="M20 18l12-6 12 6v16l-12 6-12-6z" fill="#3dd5ff" />
-    <path d="M20 34l12 6v12l-12-6z" fill="#28a3d6" />
-    <path d="M44 34l-12 6v12l12-6z" fill="#1c7fb0" />
-    <path d="M20 18l12 6 12-6" fill="none" stroke="#8af2ff" />
+  <g transform="translate(16 16) scale(0.5)">
+    <rect width="64" height="64" rx="12" fill="#141a24" />
+    <g stroke="#0f1218" stroke-width="2" stroke-linejoin="round">
+      <path d="M20 18l12-6 12 6v16l-12 6-12-6z" fill="#3dd5ff" />
+      <path d="M20 34l12 6v12l-12-6z" fill="#28a3d6" />
+      <path d="M44 34l-12 6v12l12-6z" fill="#1c7fb0" />
+      <path d="M20 18l12 6 12-6" fill="none" stroke="#8af2ff" />
+    </g>
+    <circle cx="32" cy="30" r="6" fill="#0f1218" />
+    <circle cx="32" cy="30" r="4" fill="#8af2ff" />
   </g>
-  <circle cx="32" cy="30" r="6" fill="#0f1218" />
-  <circle cx="32" cy="30" r="4" fill="#8af2ff" />
 </svg>

--- a/public/images/items/storage_shed.svg
+++ b/public/images/items/storage_shed.svg
@@ -1,11 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="12" fill="#1f1a16" />
-  <g stroke="#0f0b08" stroke-width="2" stroke-linejoin="round">
-    <path d="M12 30l20-14 20 14v20H12z" fill="#7b4a1f" />
-    <path d="M18 32h28v16H18z" fill="#9b5f28" />
-    <path d="M24 34h16v12H24z" fill="#c47a34" />
-    <path d="M12 30h40" fill="none" stroke="#d99c62" />
-    <path d="M32 16v14" fill="none" stroke="#d99c62" />
+  <g transform="translate(16 16) scale(0.5)">
+    <rect width="64" height="64" rx="12" fill="#1f1a16" />
+    <g stroke="#0f0b08" stroke-width="2" stroke-linejoin="round">
+      <path d="M12 30l20-14 20 14v20H12z" fill="#7b4a1f" />
+      <path d="M18 32h28v16H18z" fill="#9b5f28" />
+      <path d="M24 34h16v12H24z" fill="#c47a34" />
+      <path d="M12 30h40" fill="none" stroke="#d99c62" />
+      <path d="M32 16v14" fill="none" stroke="#d99c62" />
+    </g>
+    <circle cx="30" cy="42" r="2" fill="#f1d3a5" />
   </g>
-  <circle cx="30" cy="42" r="2" fill="#f1d3a5" />
 </svg>

--- a/public/images/items/water_well.svg
+++ b/public/images/items/water_well.svg
@@ -1,12 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="12" fill="#1a252d" />
-  <g stroke="#101921" stroke-width="2" stroke-linejoin="round">
-    <rect x="14" y="16" width="8" height="36" rx="3" fill="#835634" />
-    <rect x="42" y="16" width="8" height="36" rx="3" fill="#835634" />
-    <rect x="18" y="16" width="28" height="6" rx="3" fill="#ab7040" />
-    <rect x="20" y="28" width="24" height="16" rx="6" fill="#2e4859" />
-    <rect x="24" y="32" width="16" height="12" rx="5" fill="#4fa9d8" />
-    <circle cx="32" cy="20" r="4" fill="#d9e3ea" />
+  <g transform="translate(16 16) scale(0.5)">
+    <rect width="64" height="64" rx="12" fill="#1a252d" />
+    <g stroke="#101921" stroke-width="2" stroke-linejoin="round">
+      <rect x="14" y="16" width="8" height="36" rx="3" fill="#835634" />
+      <rect x="42" y="16" width="8" height="36" rx="3" fill="#835634" />
+      <rect x="18" y="16" width="28" height="6" rx="3" fill="#ab7040" />
+      <rect x="20" y="28" width="24" height="16" rx="6" fill="#2e4859" />
+      <rect x="24" y="32" width="16" height="12" rx="5" fill="#4fa9d8" />
+      <circle cx="32" cy="20" r="4" fill="#d9e3ea" />
+    </g>
+    <path d="M32 18v12" stroke="#d9e3ea" stroke-width="2" stroke-linecap="round" />
   </g>
-  <path d="M32 18v12" stroke="#d9e3ea" stroke-width="2" stroke-linecap="round" />
 </svg>

--- a/public/images/resources/brick_ceb.svg
+++ b/public/images/resources/brick_ceb.svg
@@ -1,16 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="10" fill="#362117" />
-  <g stroke="#2a160f" stroke-width="2" stroke-linejoin="round">
-    <path d="M14 26l22-8 16 8-22 8z" fill="#9a5332" />
-    <path d="M14 38l22-8 16 8-22 8z" fill="#b6633b" />
-    <path d="M14 50l22-8 16 8-22 8z" fill="#ce7848" />
-  </g>
-  <g fill="#f4c49b" opacity="0.45">
-    <circle cx="30" cy="24" r="2" />
-    <circle cx="42" cy="30" r="1.8" />
-    <circle cx="28" cy="36" r="2" />
-    <circle cx="40" cy="42" r="1.8" />
-    <circle cx="26" cy="48" r="2" />
-    <circle cx="38" cy="54" r="1.6" />
+  <g transform="translate(16 16) scale(0.5)">
+    <rect width="64" height="64" rx="10" fill="#362117" />
+    <g stroke="#2a160f" stroke-width="2" stroke-linejoin="round">
+      <path d="M14 26l22-8 16 8-22 8z" fill="#9a5332" />
+      <path d="M14 38l22-8 16 8-22 8z" fill="#b6633b" />
+      <path d="M14 50l22-8 16 8-22 8z" fill="#ce7848" />
+    </g>
+    <g fill="#f4c49b" opacity="0.45">
+      <circle cx="30" cy="24" r="2" />
+      <circle cx="42" cy="30" r="1.8" />
+      <circle cx="28" cy="36" r="2" />
+      <circle cx="40" cy="42" r="1.8" />
+      <circle cx="26" cy="48" r="2" />
+      <circle cx="38" cy="54" r="1.6" />
+    </g>
   </g>
 </svg>

--- a/public/images/resources/clay.svg
+++ b/public/images/resources/clay.svg
@@ -1,8 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="10" fill="#833c20" />
-  <path d="M12 44c3-9 10-18 20-18s17 9 20 18H12z" fill="#a64f28" />
-  <path d="M18 44c2-6 7-11 14-11s12 5 14 11H18z" fill="#c25b2d" />
-  <path d="M20 32c2-2 4-3 6-3s4 1 6 3" fill="none" stroke="#d48052" stroke-width="3" stroke-linecap="round" opacity="0.6" />
-  <circle cx="26" cy="38" r="2.3" fill="#612b14" opacity="0.4" />
-  <circle cx="38" cy="36" r="2" fill="#612b14" opacity="0.35" />
+  <g transform="translate(16 16) scale(0.5)">
+    <rect width="64" height="64" rx="10" fill="#833c20" />
+    <path d="M12 44c3-9 10-18 20-18s17 9 20 18H12z" fill="#a64f28" />
+    <path d="M18 44c2-6 7-11 14-11s12 5 14 11H18z" fill="#c25b2d" />
+    <path d="M20 32c2-2 4-3 6-3s4 1 6 3" fill="none" stroke="#d48052" stroke-width="3" stroke-linecap="round" opacity="0.6" />
+    <circle cx="26" cy="38" r="2.3" fill="#612b14" opacity="0.4" />
+    <circle cx="38" cy="36" r="2" fill="#612b14" opacity="0.35" />
+  </g>
 </svg>

--- a/public/images/resources/sand.svg
+++ b/public/images/resources/sand.svg
@@ -1,8 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="10" fill="#cfa463" />
-  <path d="M8 42c6-6 14-9 24-9s18 3 24 9H8z" fill="#e3c78d" />
-  <path d="M8 46c6-4 14-6 24-6s18 2 24 6H8z" fill="#d4b879" />
-  <path d="M12 36c4-2 8-2 12 0s8 2 12 0 8-2 12 0" fill="none" stroke="#f3dfb4" stroke-width="2.5" stroke-linecap="round" opacity="0.6" />
-  <circle cx="20" cy="40" r="2" fill="#b88843" opacity="0.5" />
-  <circle cx="40" cy="34" r="1.8" fill="#b88843" opacity="0.45" />
+  <g transform="translate(16 16) scale(0.5)">
+    <rect width="64" height="64" rx="10" fill="#cfa463" />
+    <path d="M8 42c6-6 14-9 24-9s18 3 24 9H8z" fill="#e3c78d" />
+    <path d="M8 46c6-4 14-6 24-6s18 2 24 6H8z" fill="#d4b879" />
+    <path d="M12 36c4-2 8-2 12 0s8 2 12 0 8-2 12 0" fill="none" stroke="#f3dfb4" stroke-width="2.5" stroke-linecap="round" opacity="0.6" />
+    <circle cx="20" cy="40" r="2" fill="#b88843" opacity="0.5" />
+    <circle cx="40" cy="34" r="1.8" fill="#b88843" opacity="0.45" />
+  </g>
 </svg>

--- a/public/images/resources/scrap_metal.svg
+++ b/public/images/resources/scrap_metal.svg
@@ -1,12 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="10" fill="#2a323a" />
-  <g fill="#8fa3ad" stroke="#1a2026" stroke-width="2" stroke-linejoin="round">
-    <path d="M12 40l12-22 16 8 12-6 4 18-10 10-18-2z" />
-    <path d="M18 48l6-12 8 2 2 10z" fill="#b8c8d0" />
-  </g>
-  <g fill="#cfdbe2" opacity="0.6">
-    <circle cx="28" cy="24" r="2" />
-    <circle cx="44" cy="28" r="1.6" />
-    <circle cx="34" cy="40" r="2" />
+  <g transform="translate(16 16) scale(0.5)">
+    <rect width="64" height="64" rx="10" fill="#2a323a" />
+    <g fill="#8fa3ad" stroke="#1a2026" stroke-width="2" stroke-linejoin="round">
+      <path d="M12 40l12-22 16 8 12-6 4 18-10 10-18-2z" />
+      <path d="M18 48l6-12 8 2 2 10z" fill="#b8c8d0" />
+    </g>
+    <g fill="#cfdbe2" opacity="0.6">
+      <circle cx="28" cy="24" r="2" />
+      <circle cx="44" cy="28" r="1.6" />
+      <circle cx="34" cy="40" r="2" />
+    </g>
   </g>
 </svg>

--- a/public/images/resources/soil.svg
+++ b/public/images/resources/soil.svg
@@ -1,8 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="10" fill="#3a2514" />
-  <path d="M10 44c4-10 12-16 22-16s18 6 22 16H10z" fill="#5c3b22" />
-  <path d="M14 44c3-6 9-10 18-10s15 4 18 10H14z" fill="#6b4526" />
-  <circle cx="22" cy="36" r="2.5" fill="#2b1a0f" opacity="0.4" />
-  <circle cx="34" cy="32" r="1.8" fill="#2b1a0f" opacity="0.4" />
-  <circle cx="40" cy="38" r="1.6" fill="#2b1a0f" opacity="0.35" />
+  <g transform="translate(16 16) scale(0.5)">
+    <rect width="64" height="64" rx="10" fill="#3a2514" />
+    <path d="M10 44c4-10 12-16 22-16s18 6 22 16H10z" fill="#5c3b22" />
+    <path d="M14 44c3-6 9-10 18-10s15 4 18 10H14z" fill="#6b4526" />
+    <circle cx="22" cy="36" r="2.5" fill="#2b1a0f" opacity="0.4" />
+    <circle cx="34" cy="32" r="1.8" fill="#2b1a0f" opacity="0.4" />
+    <circle cx="40" cy="38" r="1.6" fill="#2b1a0f" opacity="0.35" />
+  </g>
 </svg>

--- a/public/images/resources/water.svg
+++ b/public/images/resources/water.svg
@@ -1,6 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="10" fill="#12334d" />
-  <path d="M32 12c8 12 16 22 16 30 0 9-7 16-16 16s-16-7-16-16c0-8 8-18 16-30z" fill="#4ac2f1" />
-  <path d="M32 20c6 9 12 17 12 22a12 12 0 0 1-24 0c0-5 6-13 12-22z" fill="#70d6ff" />
-  <path d="M24 44c2 3 5 5 8 5s6-2 8-5" fill="none" stroke="#d8f5ff" stroke-width="2" stroke-linecap="round" opacity="0.7" />
+  <g transform="translate(16 16) scale(0.5)">
+    <rect width="64" height="64" rx="10" fill="#12334d" />
+    <path d="M32 12c8 12 16 22 16 30 0 9-7 16-16 16s-16-7-16-16c0-8 8-18 16-30z" fill="#4ac2f1" />
+    <path d="M32 20c6 9 12 17 12 22a12 12 0 0 1-24 0c0-5 6-13 12-22z" fill="#70d6ff" />
+    <path d="M24 44c2 3 5 5 8 5s6-2 8-5" fill="none" stroke="#d8f5ff" stroke-width="2" stroke-linecap="round" opacity="0.7" />
+  </g>
 </svg>

--- a/public/images/resources/wood.svg
+++ b/public/images/resources/wood.svg
@@ -1,16 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="10" fill="#3b2a1f" />
-  <g stroke="#24170f" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    <rect x="12" y="18" width="40" height="10" rx="5" fill="#7a4d28" />
-    <rect x="16" y="30" width="36" height="10" rx="5" fill="#8e5d31" />
-    <rect x="14" y="42" width="34" height="10" rx="5" fill="#a26d3a" />
-  </g>
-  <g fill="#cfa578" opacity="0.5">
-    <circle cx="20" cy="23" r="2.6" />
-    <circle cx="36" cy="23" r="2" />
-    <circle cx="26" cy="35" r="2.2" />
-    <circle cx="44" cy="35" r="1.8" />
-    <circle cx="24" cy="47" r="2" />
-    <circle cx="38" cy="47" r="1.8" />
+  <g transform="translate(16 16) scale(0.5)">
+    <rect width="64" height="64" rx="10" fill="#3b2a1f" />
+    <g stroke="#24170f" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="12" y="18" width="40" height="10" rx="5" fill="#7a4d28" />
+      <rect x="16" y="30" width="36" height="10" rx="5" fill="#8e5d31" />
+      <rect x="14" y="42" width="34" height="10" rx="5" fill="#a26d3a" />
+    </g>
+    <g fill="#cfa578" opacity="0.5">
+      <circle cx="20" cy="23" r="2.6" />
+      <circle cx="36" cy="23" r="2" />
+      <circle cx="26" cy="35" r="2.2" />
+      <circle cx="44" cy="35" r="1.8" />
+      <circle cx="24" cy="47" r="2" />
+      <circle cx="38" cy="47" r="1.8" />
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- shrink the item SVG icons by wrapping their content in a centered 0.5 scale group
- apply the same scaling to resource and terrain SVG assets for consistent smaller visuals

## Testing
- not run (asset change only)


------
https://chatgpt.com/codex/tasks/task_e_68e70cbe554c832385a57b7831088547